### PR TITLE
Fix Hoshi placeholder placement

### DIFF
--- a/TextFieldEffects/TextFieldEffects/HoshiTextField.swift
+++ b/TextFieldEffects/TextFieldEffects/HoshiTextField.swift
@@ -80,8 +80,6 @@ import UIKit
         layer.addSublayer(inactiveBorderLayer)
         layer.addSublayer(activeBorderLayer)
         addSubview(placeholderLabel)
-        
-        activePlaceholderPoint = CGPoint(x: placeholderLabel.frame.origin.x, y: placeholderLabel.frame.origin.y - placeholderLabel.frame.size.height - placeholderInsets.y)
     }
     
     override public func animateViewsForTextEntry() {
@@ -160,6 +158,8 @@ import UIKit
         }
         placeholderLabel.frame = CGRect(x: originX, y: textRect.height/2,
             width: placeholderLabel.bounds.width, height: placeholderLabel.bounds.height)
+        activePlaceholderPoint = CGPoint(x: placeholderLabel.frame.origin.x, y: placeholderLabel.frame.origin.y - placeholderLabel.frame.size.height - placeholderInsets.y)
+
     }
     
     // MARK: - Overrides


### PR DESCRIPTION
When some text was already set in a Hoshi text field, placeholder would be displayed always to the left and would be hidden if the text field was focused.
Example for center alignment: 
![textfieldeffectsbug](https://cloud.githubusercontent.com/assets/3706309/10773834/0d75778a-7cfe-11e5-9978-f32c0458cfb1.gif)