### PR TITLE
Remove unnecessary Foundation import

### DIFF
--- a/TextFieldEffects/TextFieldEffects/TextFieldsEffects.swift
+++ b/TextFieldEffects/TextFieldEffects/TextFieldsEffects.swift
@@ -6,7 +6,6 @@
 //  Copyright (c) 2015 Raul Riera. All rights reserved.
 //
 
-import Foundation
 import UIKit
 
 extension String {


### PR DESCRIPTION
See http://stackoverflow.com/questions/25029835/swift-class-vs-cocoa-touch-class-in-xcode6 for additional reference.

Awesome project btw! :+1: 