### PR TITLE
HoshiTextField clear button位置和文字对齐

### DIFF
--- a/TextFieldEffects/TextFieldEffects/HoshiTextField.swift
+++ b/TextFieldEffects/TextFieldEffects/HoshiTextField.swift
@@ -187,4 +187,11 @@ import UIKit
         return CGRectOffset(bounds, textFieldInsets.x, textFieldInsets.y)
     }
     
+    public override func clearButtonRectForBounds(bounds: CGRect) -> CGRect {
+        var rect = super.clearButtonRectForBounds(bounds)
+        let textRect = textRectForBounds(bounds)
+        rect.origin.y += textRect.height/4
+        return rect
+    }
+    
 }

--- a/TextFieldEffects/TextFieldEffects/HoshiTextField.swift
+++ b/TextFieldEffects/TextFieldEffects/HoshiTextField.swift
@@ -180,7 +180,14 @@ import UIKit
     // MARK: - Overrides
     
     override public func editingRectForBounds(bounds: CGRect) -> CGRect {
-        return CGRectOffset(bounds, textFieldInsets.x, textFieldInsets.y)
+        if self.clearButtonMode  != .Never {
+            var rect = CGRectOffset(bounds, textFieldInsets.x, textFieldInsets.y)
+            rect.size.width -= bounds.width - CGRectGetMinX(clearButtonRectForBounds(bounds))
+            return rect
+        } else {
+            return CGRectOffset(bounds, textFieldInsets.x, textFieldInsets.y)
+        }
+        
     }
     
     override public func textRectForBounds(bounds: CGRect) -> CGRect {


### PR DESCRIPTION
当HoshiTextField设置clear button的时候，clear button纵向中心是在整个textField的纵向中心，和文字不对齐。修复这个问题，使得clear button和文字对齐
