### PR TITLE
[Remove M_PI] For old versions of Swift, we use M_PI. To refer to the…

### DIFF
--- a/TextFieldEffects/TextFieldEffects/YokoTextField.swift
+++ b/TextFieldEffects/TextFieldEffects/YokoTextField.swift
@@ -200,7 +200,7 @@ import UIKit
         
         var rotationAndPerspectiveTransform = CATransform3DIdentity
         rotationAndPerspectiveTransform.m34 = 1.0/800
-        let radians = ((-90) / 180.0 * CGFloat(M_PI))
+        let radians = ((-90) / 180.0 * CGFloat.pi)
         rotationAndPerspectiveTransform = CATransform3DRotate(rotationAndPerspectiveTransform, radians, 1.0, 0.0, 0.0)
         return rotationAndPerspectiveTransform
     }


### PR DESCRIPTION
[Remove M_PI] For old versions of Swift, we use M_PI. To refer to the pi constant, Swift 3 integrates the pi constant in Float,  CGFloat and Double