### PR TITLE
Fix HoshiTextField borderColor change

### DIFF
--- a/TextFieldEffects/TextFieldEffects/HoshiTextField.swift
+++ b/TextFieldEffects/TextFieldEffects/HoshiTextField.swift
@@ -109,7 +109,7 @@ import UIKit
 			self.placeholderLabel.alpha = 1.0
 		})
 
-        activeBorderLayer.frame = rectForBorder(borderThickness.active, isFilled: true)
+        activeBorderLayer.frame = rectForBorder(borderThickness.active, isFilled: self.isFirstResponder)
     }
     
     override open func animateViewsForTextDisplay() {

--- a/TextFieldEffects/TextFieldEffects/HoshiTextField.swift
+++ b/TextFieldEffects/TextFieldEffects/HoshiTextField.swift
@@ -131,7 +131,7 @@ import UIKit
         inactiveBorderLayer.frame = rectForBorder(borderThickness.inactive, isFilled: true)
         inactiveBorderLayer.backgroundColor = borderInactiveColor?.cgColor
         
-        activeBorderLayer.frame = rectForBorder(borderThickness.active, isFilled: false)
+        activeBorderLayer.frame = rectForBorder(borderThickness.active, isFilled: self.isFirstResponder)
         activeBorderLayer.backgroundColor = borderActiveColor?.cgColor
     }
     


### PR DESCRIPTION
Fix HoshiTextField borderColor change when text field is the first responder. Active border should be filled if the textfield is the first responder.