### PR TITLE
adjust animation of placeholder to iOS12 new feature:AutoFill

### DIFF
--- a/TextFieldEffects/TextFieldEffects/TextFieldEffects.swift
+++ b/TextFieldEffects/TextFieldEffects/TextFieldEffects.swift
@@ -92,7 +92,7 @@ open class TextFieldEffects : UITextField {
     
     override open var text: String? {
         didSet {
-            if let text = text, text.isNotEmpty {
+            if let text = text, text.isNotEmpty || isFirstResponder {
                 animateViewsForTextEntry()
             } else {
                 animateViewsForTextDisplay()


### PR DESCRIPTION
When I use iOS 12 new feature of AutoFill to fill textField,the placeholder animation did't show,and the text filled overlapped on the placeholder.For some reason I don't know,the fill text did't trigger the didSet action of text,so the animation did't show.But I think the animateViewsForTextEntry() shoud execute when the textField become first responder,and this solution works!