### PR TITLE
Added swift version in the podspec

### DIFF
--- a/TextFieldEffects.podspec
+++ b/TextFieldEffects.podspec
@@ -56,7 +56,8 @@ Pod::Spec.new do |s|
   #  the deployment target. You can optionally include the target after the platform.
   #
 
-  s.platform     = :ios, '8.0'
+  s.platform      = :ios, '8.0'
+  s.swift_version = '4.2'
 
   # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   #


### PR DESCRIPTION
Hey!

I am using swift 3.0 for one of my projects. Since when you don't specify swift version in the pod it is automatically set to the version in the project, but the current version of the pod is not compatible with swift 3.0. Therefore I have added a line to specify the swift version for the pod. 

Great job on TextFieldEffects. I use them in most of my apps!