### PR TITLE
Method isNotEmpty it is not visible after pod install.

### DIFF
--- a/TextFieldEffects/TextFieldEffects/TextFieldEffects.swift
+++ b/TextFieldEffects/TextFieldEffects/TextFieldEffects.swift
@@ -12,7 +12,7 @@ extension String {
     /**
     true if self contains characters.
     */
-	var isNotEmpty: Bool {
+	public var isNotEmpty: Bool {
         return !isEmpty
     }
 }


### PR DESCRIPTION
After pod install using swift 4.2 and your library(TextFieldEffects), the isNotEmpty(extension) var is not visible to use in project.