### PR TITLE
Update YoshikoTextField.swift

### DIFF
--- a/TextFieldEffects/TextFieldEffects/YoshikoTextField.swift
+++ b/TextFieldEffects/TextFieldEffects/YoshikoTextField.swift
@@ -201,7 +201,10 @@ import UIKit
     }
     
     override open func textRect(forBounds bounds: CGRect) -> CGRect {
-        return bounds.offsetBy(dx: textFieldInsets.x, dy: textFieldInsets.y + placeholderHeight / 2)
+        return CGRect(x: textFieldInsets.x,
+                      y: placeholderHeight,
+                      width: bounds.width - (textFieldInsets.x * 2),
+                      height: bounds.height - placeholderHeight)
     }
     
     // MARK: - Interface Builder


### PR DESCRIPTION
Fixed issue where text rect would overlap the textfield's bounds on the right side for Yoshiko TextField.

Check the before and after when debugging the view hierarchy in Xcode:
![Before   After](https://user-images.githubusercontent.com/18062144/165190777-0d1465ff-1d08-4d00-ba12-4e2fc95b6780.png)

